### PR TITLE
Fix: use dropout parameter

### DIFF
--- a/models/vgg_classification.py
+++ b/models/vgg_classification.py
@@ -104,7 +104,7 @@ class VggClassification(VGG):
                     param.requires_grad = False
 
         # probability of dropout
-        self.dropout = nn.Dropout()
+        self.dropout = nn.Dropout(dropout)
 
         # final FC layers: from N to 1 (probability for illuminant)
         final_n = 1


### PR DESCRIPTION
The dropout parameter passed to the class constructor is not used. The default p=0.5 of torch.nn.Dropout is always used instead.